### PR TITLE
Implementation of coin-level freezing (utxo freezing)

### DIFF
--- a/gui/qt/address_list.py
+++ b/gui/qt/address_list.py
@@ -165,7 +165,7 @@ class AddressList(MyTreeWidget):
         if not all(self.wallet.is_frozen(addr) for addr in addrs):
             menu.addAction(_("Freeze"), partial(freeze, addrs, True))
 
-        coins = self.wallet.get_utxos(addrs)
+        coins = self.wallet.get_spendable_coins(domain = addrs, config = self.config)
         if coins:
             menu.addAction(_("Spend from"),
                            partial(self.parent.spend_coins, coins))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2005,6 +2005,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.utxo_list.update()
         self.update_fee()
 
+    def set_frozen_coins_state(self, utxos, freeze):
+        self.wallet.set_frozen_coin_state(utxos, freeze)
+        self.address_list.update()
+        self.utxo_list.update()
+        self.update_fee()
+
     def create_converter_tab(self):
 
         source_address = QLineEdit()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -2005,9 +2005,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.utxo_list.update()
         self.update_fee()
 
-    def set_frozen_coins_state(self, utxos, freeze):
+    def set_frozen_coin_state(self, utxos, freeze):
         self.wallet.set_frozen_coin_state(utxos, freeze)
-        self.address_list.update()
         self.utxo_list.update()
         self.update_fee()
 

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -60,7 +60,7 @@ class UTXOList(MyTreeWidget):
             utxo_item.setFont(4, QFont(MONOSPACE_FONT))
             utxo_item.setData(0, Qt.UserRole, name)
             a_frozen = self.wallet.is_frozen(address)
-            c_frozen = self.wallet.is_frozen_coin(x)
+            c_frozen = x['is_frozen_coin']
             if a_frozen and not c_frozen:
                 # address is frozen, coin is not frozen
                 # emulate the "Look" off the address_list .py's frozen entry

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -60,7 +60,7 @@ class UTXOList(MyTreeWidget):
             utxo_item.setFont(4, QFont(MONOSPACE_FONT))
             utxo_item.setData(0, Qt.UserRole, name)
             a_frozen = self.wallet.is_frozen(address)
-            c_frozen = x.get('is_frozen_coin', False)
+            c_frozen = self.wallet.is_frozen_coin(x)
             if a_frozen and not c_frozen:
                 # address is frozen, coin is not frozen
                 # emulate the "Look" off the address_list .py's frozen entry
@@ -86,7 +86,7 @@ class UTXOList(MyTreeWidget):
         if not selected:
             return
         menu = QMenu()
-        coins = list(filter(lambda x: self.get_name(x) in selected, self.utxos))
+        coins = filter(lambda x: self.get_name(x) in selected, self.utxos)
         spendable_coins = list(filter(lambda x: not selected.get(self.get_name(x), ''), coins))
         # Unconditionally add the "Spend" option but leave it disabled if there are no spendable_coins
         menu.addAction(_("Spend"), lambda: self.parent.spend_coins(spendable_coins)).setEnabled(bool(spendable_coins))

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -115,16 +115,16 @@ class UTXOList(MyTreeWidget):
         else:
             # multi-selection
             menu.addSeparator()
-            if any([True for flags in selected.values() if 'c' not in flags]):
+            if any(['c' not in flags for flags in selected.values()]):
                 # they have some coin-level non-frozen in the selection, so add the menu action "Freeze coins"
                 menu.addAction(_("Freeze Coins"), lambda: self.set_frozen_coins(list(selected.keys()), True))
-            if any([True for flags in selected.values() if 'c' in flags]):
+            if any(['c' in flags for flags in selected.values()]):
                 # they have some coin-level frozen in the selection, so add the menu action "Unfreeze coins"
                 menu.addAction(_("Unfreeze Coins"), lambda: self.set_frozen_coins(list(selected.keys()), False))
-            if any([True for flags in selected.values() if 'a' not in flags]):
+            if any(['a' not in flags for flags in selected.values()]):
                 # they have some address-level non-frozen in the selection, so add the menu action "Freeze addresses"
                 menu.addAction(_("Freeze Addresses"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), True))
-            if any([True for flags in selected.values() if 'a' in flags]):
+            if any(['a' in flags for flags in selected.values()]):
                 # they have some address-level frozen in the selection, so add the menu action "Unfreeze addresses"
                 menu.addAction(_("Unfreeze Addresses"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), False))
 

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -136,7 +136,7 @@ class UTXOList(MyTreeWidget):
 
     def set_frozen_coins(self, coins, b):
         if self.parent:
-            self.parent.set_frozen_coins_state(coins, b)
+            self.parent.set_frozen_coin_state(coins, b)
 
     def set_frozen_addresses_for_coins(self, coins, b):
         if not self.parent: return

--- a/gui/qt/utxo_list.py
+++ b/gui/qt/utxo_list.py
@@ -33,14 +33,18 @@ class UTXOList(MyTreeWidget):
         MyTreeWidget.__init__(self, parent, self.create_menu, [ _('Address'), _('Label'), _('Amount'), _('Height'), _('Output point')], 1)
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
+        # force attributes to always be defined, even if None, at construction.
+        self.wallet = self.parent.wallet if hasattr(self.parent, 'wallet') else None
+        self.utxos = list()
 
     def get_name(self, x):
         return x.get('prevout_hash') + ":%d"%x.get('prevout_n')
 
     def on_update(self):
-        self.wallet = self.parent.wallet
+        prev_selection = self.get_selected() # cache previous selection, if any
         self.clear()
-        self.utxos = self.wallet.get_utxos(get_all=True)
+        self.wallet = self.parent.wallet
+        self.utxos = self.wallet.get_utxos()
         for x in self.utxos:
             address = x['address']
             address_text = address.to_ui_string()
@@ -51,28 +55,95 @@ class UTXOList(MyTreeWidget):
             utxo_item = SortableTreeWidgetItem([address_text, label, amount,
                                          str(height),
                                          name[0:10] + '...' + name[-2:]])
+            utxo_item.DataRole = Qt.UserRole+100 # set this here to avoid sorting based on Qt.UserRole+1
             utxo_item.setFont(0, QFont(MONOSPACE_FONT))
             utxo_item.setFont(4, QFont(MONOSPACE_FONT))
             utxo_item.setData(0, Qt.UserRole, name)
-            if self.wallet.is_frozen(address):
+            a_frozen = self.wallet.is_frozen(address)
+            c_frozen = x.get('is_frozen_coin', False)
+            if a_frozen and not c_frozen:
+                # address is frozen, coin is not frozen
+                # emulate the "Look" off the address_list .py's frozen entry
+                utxo_item.setBackground(0, QColor('lightblue'))
+            elif c_frozen and not a_frozen:
+                # coin is frozen, address is not frozen
                 utxo_item.setBackground(0, ColorScheme.BLUE.as_color(True))
+            elif c_frozen and a_frozen:
+                # both coin and address are frozen so color-code it to indicate that.
+                utxo_item.setBackground(0, QColor('lightblue'))
+                utxo_item.setForeground(0, QColor('#3399ff'))
+            # save the address-level-frozen and coin-level-frozen flags to the data item for retrieval later in create_menu() below.
+            utxo_item.setData(0, Qt.UserRole+1, "{}{}".format(("a" if a_frozen else ""), ("c" if c_frozen else "")))
             self.addChild(utxo_item)
+            utxo_item.setSelected(name in prev_selection) # restore previous selection
+
+    def get_selected(self):
+        return { x.data(0, Qt.UserRole) : x.data(0, Qt.UserRole+1) # dict of "name" -> frozen flags string (eg: "ac")
+                for x in self.selectedItems() }
 
     def create_menu(self, position):
-        selected = [x.data(0, Qt.UserRole) for x in self.selectedItems()]
+        selected = self.get_selected()
         if not selected:
             return
         menu = QMenu()
-        coins = filter(lambda x: self.get_name(x) in selected, self.utxos)
-
-        menu.addAction(_("Spend"), lambda: self.parent.spend_coins(coins))
+        coins = list(filter(lambda x: self.get_name(x) in selected, self.utxos))
+        spendable_coins = list(filter(lambda x: not selected.get(self.get_name(x), ''), coins))
+        # Unconditionally add the "Spend" option but leave it disabled if there are no spendable_coins
+        menu.addAction(_("Spend"), lambda: self.parent.spend_coins(spendable_coins)).setEnabled(bool(spendable_coins))
         if len(selected) == 1:
-            txid = selected[0].split(':')[0]
+            # single selection, offer them the "Details" option and also coin/address "freeze" status, if any
+            txid = list(selected.keys())[0].split(':')[0]
+            frozen_flags = list(selected.values())[0]
             tx = self.wallet.transactions.get(txid)
             menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx))
+            act = None
+            needsep = True
+            if 'c' in frozen_flags:
+                menu.addSeparator()
+                menu.addAction(_("Coin is frozen"), lambda: None).setEnabled(False)
+                menu.addAction(_("Unfreeze Coin"), lambda: self.set_frozen_coins(list(selected.keys()), False))
+                menu.addSeparator()
+                needsep = False
+            else:
+                menu.addAction(_("Freeze Coin"), lambda: self.set_frozen_coins(list(selected.keys()), True))
+            if 'a' in frozen_flags:
+                if needsep: menu.addSeparator()
+                menu.addAction(_("Address is frozen"), lambda: None).setEnabled(False)
+                menu.addAction(_("Unfreeze Address"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), False))
+            else:
+                menu.addAction(_("Freeze Address"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), True))
+        else:
+            # multi-selection
+            menu.addSeparator()
+            if any([True for flags in selected.values() if 'c' not in flags]):
+                # they have some coin-level non-frozen in the selection, so add the menu action "Freeze coins"
+                menu.addAction(_("Freeze Coins"), lambda: self.set_frozen_coins(list(selected.keys()), True))
+            if any([True for flags in selected.values() if 'c' in flags]):
+                # they have some coin-level frozen in the selection, so add the menu action "Unfreeze coins"
+                menu.addAction(_("Unfreeze Coins"), lambda: self.set_frozen_coins(list(selected.keys()), False))
+            if any([True for flags in selected.values() if 'a' not in flags]):
+                # they have some address-level non-frozen in the selection, so add the menu action "Freeze addresses"
+                menu.addAction(_("Freeze Addresses"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), True))
+            if any([True for flags in selected.values() if 'a' in flags]):
+                # they have some address-level frozen in the selection, so add the menu action "Unfreeze addresses"
+                menu.addAction(_("Unfreeze Addresses"), lambda: self.set_frozen_addresses_for_coins(list(selected.keys()), False))
 
         menu.exec_(self.viewport().mapToGlobal(position))
 
     def on_permit_edit(self, item, column):
         # disable editing fields in this tab (labels)
         return False
+
+    def set_frozen_coins(self, coins, b):
+        if self.parent:
+            self.parent.set_frozen_coins_state(coins, b)
+
+    def set_frozen_addresses_for_coins(self, coins, b):
+        if not self.parent: return
+        addrs = set()
+        for utxo in self.utxos:
+            name = self.get_name(utxo)
+            if name in coins:
+                addrs.add(utxo['address'])
+        if addrs:
+            self.parent.set_frozen_state(list(addrs), b)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1449,6 +1449,7 @@ class Abstract_Wallet(PrintError):
             ret = ("{}:{}".format(utxo['prevout_hash'], utxo['prevout_n'])) in self.frozen_coins
             if ret != utxo['is_frozen_coin']:
                 self.print_error("*** WARNING: utxo has stale is_frozen_coin flag")
+                utxo['is_frozen_coin'] = ret # update stale flag
             return ret
         return utxo in self.frozen_coins
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -784,7 +784,7 @@ class Abstract_Wallet(PrintError):
         for addr in domain:
             utxos = self.get_addr_utxo(addr, slpTokenId = self.send_slpTokenId, get_all = get_all)
             for x in utxos.values():
-                if exclude_frozen and x.get('is_frozen_coin', False):
+                if exclude_frozen and x['is_frozen_coin']:
                     continue
                 if confirmed_only and x['height'] <= 0:
                     continue
@@ -1446,7 +1446,10 @@ class Abstract_Wallet(PrintError):
             Note: this is set/unset independent of 'address' level freezing. '''
         assert isinstance(utxo, (str, dict))
         if isinstance(utxo, dict):
-            return utxo.get('is_frozen_coin', False)
+            ret = ("{}:{}".format(utxo['prevout_hash'], utxo['prevout_n'])) in self.frozen_coins
+            if ret != utxo['is_frozen_coin']:
+                self.print_error("*** WARNING: utxo has stale is_frozen_coin flag")
+            return ret
         return utxo in self.frozen_coins
 
     def set_frozen_state(self, addrs, freeze):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -186,8 +186,7 @@ class Abstract_Wallet(PrintError):
         # Frozen coins (UTXOs) -- note that we have 2 independent levels of "freezing": address-level and coin-level.
         # The two types of freezing are flagged independently of each other and 'spendable' is defined as a coin that satisfies
         # BOTH levels of freezing.
-        frozen_coins = storage.get('frozen_coins', [])
-        self.frozen_coins = set(frozen_coins)
+        self.frozen_coins = set(storage.get('frozen_coins', []))
         # address -> list(txid, height)
         history = storage.get('addr_history',{})
         self._history = self.to_Address_dict(history)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -183,6 +183,11 @@ class Abstract_Wallet(PrintError):
         frozen_addresses = storage.get('frozen_addresses',[])
         self.frozen_addresses = set(Address.from_string(addr)
                                     for addr in frozen_addresses)
+        # Frozen coins (UTXOs) -- note that we have 2 independent levels of "freezing": address-level and coin-level.
+        # The two types of freezing are flagged independently of each other and 'spendable' is defined as a coin that satisfies
+        # BOTH levels of freezing.
+        frozen_coins = storage.get('frozen_coins', [])
+        self.frozen_coins = set(frozen_coins)
         # address -> list(txid, height)
         history = storage.get('addr_history',{})
         self._history = self.to_Address_dict(history)
@@ -686,7 +691,9 @@ class Abstract_Wallet(PrintError):
         # removes spent coins
         for txi in spent:
             coins.pop(txi)
-
+            if txi in self.frozen_coins:
+                # cleanup/detect if the 'frozen coin' was spent and remove it from the frozen coin set
+                self.frozen_coins.remove(txi)
         ### SLP stuff
         # removes token that are either unrelated, or unvalidated
         if not get_all:
@@ -705,7 +712,8 @@ class Abstract_Wallet(PrintError):
                 'prevout_n':int(prevout_n),
                 'prevout_hash':prevout_hash,
                 'height':tx_height,
-                'coinbase':is_cb
+                'coinbase':is_cb,
+                'is_frozen_coin':txo in self.frozen_coins
             }
             out[txo] = x
         return out
@@ -716,11 +724,14 @@ class Abstract_Wallet(PrintError):
         return sum([v for height, v, is_cb in received.values()])
 
     # return the balance of a bitcoin address: confirmed and matured, unconfirmed, unmatured
-    def get_addr_balance(self, address):
+    # Note that 'exclude_frozen_coins = True' only checks for coin-level freezing, not address-level.
+    def get_addr_balance(self, address, exclude_frozen_coins = False):
         assert isinstance(address, Address)
         received, sent = self.get_addr_io(address)
         c = u = x = 0
         for txo, (tx_height, v, is_cb) in received.items():
+            if exclude_frozen_coins and txo in self.frozen_coins:
+                continue
             if is_cb and tx_height + COINBASE_MATURITY > self.get_local_height():
                 x += v
             elif tx_height > 0:
@@ -765,6 +776,7 @@ class Abstract_Wallet(PrintError):
         return (valid_token_bal, unvalidated_token_bal, invalid_token_bal)
 
     def get_utxos(self, domain = None, exclude_frozen = False, mature = False, confirmed_only = False, get_all = False):
+        ''' Note that exclude_frozen = True checks for BOTH address-level and coin-level frozen status. '''
         coins = []
         if domain is None:
             domain = self.get_addresses()
@@ -773,6 +785,8 @@ class Abstract_Wallet(PrintError):
         for addr in domain:
             utxos = self.get_addr_utxo(addr, slpTokenId = self.send_slpTokenId, get_all = get_all)
             for x in utxos.values():
+                if exclude_frozen and x.get('is_frozen_coin', False):
+                    continue
                 if confirmed_only and x['height'] <= 0:
                     continue
                 if mature and x['coinbase'] and x['height'] + COINBASE_MATURITY > self.get_local_height():
@@ -788,14 +802,22 @@ class Abstract_Wallet(PrintError):
         return self.get_receiving_addresses() + self.get_change_addresses()
 
     def get_frozen_balance(self):
-        return self.get_balance(self.frozen_addresses)
+        if not self.frozen_coins:
+            # performance short-cut -- get the balance of the frozen address set only IFF we don't have any frozen coins
+            return self.get_balance(self.frozen_addresses)
+        # otherwise, do this more costly calculation...
+        cc_no_f, uu_no_f, xx_no_f = self.get_balance(None, exclude_frozen_coins = True, exclude_frozen_addresses = True)
+        cc_all, uu_all, xx_all = self.get_balance(None, exclude_frozen_coins = False, exclude_frozen_addresses = False)
+        return (cc_all-cc_no_f), (uu_all-uu_no_f), (xx_all-xx_no_f)
 
-    def get_balance(self, domain=None):
+    def get_balance(self, domain=None, exclude_frozen_coins=False, exclude_frozen_addresses=False):
         if domain is None:
             domain = self.get_addresses()
+        if exclude_frozen_addresses:
+            domain = set(domain) - self.frozen_addresses
         cc = uu = xx = 0
         for addr in domain:
-            c, u, x = self.get_addr_balance(addr)
+            c, u, x = self.get_addr_balance(addr, exclude_frozen_coins)
             cc += c
             uu += u
             xx += x
@@ -1416,11 +1438,22 @@ class Abstract_Wallet(PrintError):
         return tx
 
     def is_frozen(self, addr):
+        ''' Address-level frozen query. Note: this is set/unset independent of 'coin' level freezing. '''
         assert isinstance(addr, Address)
         return addr in self.frozen_addresses
 
+    def is_frozen_coin(self, utxo):
+        ''' 'coin' level frozen query. `utxo' is a prevout:n string, or a dict as returned from get_utxos().
+            Note: this is set/unset independent of 'address' level freezing. '''
+        assert isinstance(utxo, (str, dict))
+        if isinstance(utxo, dict):
+            return utxo.get('is_frozen_coin', False)
+        return utxo in self.frozen_coins
+
     def set_frozen_state(self, addrs, freeze):
-        '''Set frozen state of the addresses to FREEZE, True or False'''
+        ''' Set frozen state of the addresses to FREEZE, True or False
+            Note that address-level freezing is set/unset independent of coin-level freezing, however both must
+            be satisfied for a coin to be defined as spendable.. '''
         if all(self.is_mine(addr) for addr in addrs):
             if freeze:
                 self.frozen_addresses |= set(addrs)
@@ -1431,6 +1464,32 @@ class Abstract_Wallet(PrintError):
             self.storage.put('frozen_addresses', frozen_addresses)
             return True
         return False
+
+    def set_frozen_coin_state(self, utxos, freeze):
+        ''' Set frozen state of the COINS to FREEZE, True or False.
+            utxos is a (possibly mixed) list of either "prevout:n" strings and/or coin-dicts as returned from get_utxos().
+            Note that if passing prevout:n strings as input, 'is_mine()' status is not checked for the specified coin.
+            Also note that coin-level freezing is set/unset independent of address-level freezing, however both must
+            be satisfied for a coin to be defined as spendable. '''
+        ok = 0
+        for utxo in utxos:
+            if isinstance(utxo, str):
+                if freeze:
+                    self.frozen_coins |= { utxo }
+                else:
+                    self.frozen_coins -= { utxo }
+                ok += 1
+            elif isinstance(utxo, dict) and self.is_mine(utxo['address']):
+                txo = "{}:{}".format(utxo['prevout_hash'], utxo['prevout_n'])
+                if freeze:
+                    self.frozen_coins |= { txo }
+                else:
+                    self.frozen_coins -= { txo }
+                utxo['is_frozen_coin'] = bool(freeze)
+                ok += 1
+        if ok:
+            self.storage.put('frozen_coins', list(self.frozen_coins))
+        return ok
 
     def prepare_for_verifier(self):
         # review transactions that are in the history


### PR DESCRIPTION
This is a PR also on Electron Cash main branch and may get merged in soon.

I decided to issue this PR here too because I figured such a feature might be useful for you as well.

Note coin-level freezing is independent of Address-level freezing.  The two can be frozen/unfrozen independently of each other.

Both coin-level and address-level freezing must be off on a UTXO for it to be considered for spending/spendable.

Note:
- Address tab is left unchanged (it can only control address-level freezing).
- Coins tab is where the action is at. In the coins tab you can now freeze/unfreeze both at the coin and the address level.