### PR TITLE
More verbose user agent when paying with BIP70

### DIFF
--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -54,7 +54,7 @@ from .util import FileImportFailed, FileImportFailedEncrypted
 from .transaction import Transaction
 
 
-REQUEST_HEADERS = {'Accept': 'application/bitcoincash-paymentrequest', 'User-Agent': 'Electron-Cash'}
+REQUEST_HEADERS = {'Accept': 'application/bitcoincash-paymentrequest', 'User-Agent': 'Electron-Cash/' + version.PACKAGE_VERSION + version.get_extensions()}
 ACK_HEADERS = {'Content-Type':'application/bitcoincash-payment','Accept':'application/bitcoincash-paymentack','User-Agent':'Electron-Cash'}
 
 ca_path = requests.certs.where()

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,5 +1,6 @@
 PACKAGE_VERSION = '3.5.1'  # version of the client package
 PROTOCOL_VERSION = '1.4'     # protocol version requested
+EXTENSIONS = { 'SLP': "1" }
 
 # The hash of the mnemonic seed must begin with this
 SEED_PREFIX      = '01'      # Standard wallet
@@ -13,6 +14,12 @@ import re
 
 _RX_NORMALIZER = re.compile(r'(\.0+)*$')
 _RX_VARIANT_TOKEN_PARSE = re.compile(r'^(\d+)(.+)$')
+
+def get_extensions():
+    extension_string = ''
+    for extension in EXTENSIONS:
+        extension_string = ' ' + extension + '/' + EXTENSIONS[extension]
+    return extension_string
 
 def normalize_version(v):
     """Used for PROTOCOL_VERSION normalization, e.g '1.4.0' -> (1,4) """


### PR DESCRIPTION
BIP70 payments use HTTP as carrier and therefore have the ability to use HTTP headers. The user agent header is very useful for the server to identify which protocols the wallet supports.

This PR adds a version number to the current user agent and list supported extensions according to the Mozilla User Agent standard described here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

The current extension is SLP/1, standing for SLP token type 1. If a token type 2 would appear, this extension will be SLP/2. A future user agent could look like this:

Electron-Cash/3.5.1 SLP/1 NFT/1 SLP/2

**Use cases and motivation**
When a BIP70 payment is carried out, the wallet sends a refund address. The server could use the refund address to send back an SLP token. If the wallet does not support SLP, the token could be burned. By using a verbose user agent, the server will be able to know if the receiving wallet is SLP enabled or not.