### PR TITLE
Add CashScript highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cash linguist-language=Solidity


### PR DESCRIPTION
This file tells GitHub to treat .cash files as Solidity, which has almost the same syntax as CashScript, so it enables syntax highlighting.