### PR TITLE
Build: Use different names for SLP Docker images and containers

### DIFF
--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -60,7 +60,7 @@ fi
 DOCKER_SUFFIX=ub1604
 
 info "Creating docker image ..."
-$SUDO docker build -t electroncash-appimage-builder-img-$DOCKER_SUFFIX \
+$SUDO docker build -t electroncash-slp-appimage-builder-img-$DOCKER_SUFFIX \
     -f contrib/build-linux/appimage/Dockerfile_$DOCKER_SUFFIX \
     contrib/build-linux/appimage \
     || fail "Failed to create docker image"
@@ -89,12 +89,12 @@ mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home
     -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
-    --name electroncash-appimage-builder-cont-$DOCKER_SUFFIX \
+    --name electroncash-slp-appimage-builder-cont-$DOCKER_SUFFIX \
     -v $FRESH_CLONE_DIR:/opt/electroncash:delegated \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/appimage \
     -u $(id -u $USER):$(id -g $USER) \
-    electroncash-appimage-builder-img-$DOCKER_SUFFIX \
+    electroncash-slp-appimage-builder-img-$DOCKER_SUFFIX \
     ./_build.sh $REV
 ) || fail "Build inside docker container failed"
 

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -48,7 +48,7 @@ fi
 
 
 info "Creating docker image ..."
-$SUDO docker build -t electroncash-srcdist-builder-img \
+$SUDO docker build -t electroncash-slp-srcdist-builder-img \
     contrib/build-linux/srcdist_docker \
     || fail "Failed to create docker image"
 
@@ -76,12 +76,12 @@ mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home
     -e HOME="/opt/electroncash/contrib/build-linux/home" \
     -e GIT_REPO="$GIT_REPO" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
-    --name electroncash-srcdist-builder-cont \
+    --name electroncash-slp-srcdist-builder-cont \
     -v $FRESH_CLONE_DIR:/opt/electroncash:delegated \
     --rm \
     --workdir /opt/electroncash/contrib/build-linux/srcdist_docker \
     -u $(id -u $USER):$(id -g $USER) \
-    electroncash-srcdist-builder-img \
+    electroncash-slp-srcdist-builder-img \
     ./_build.sh $REV
 ) || fail "Build inside docker container failed"
 

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -52,7 +52,7 @@ GROUP_ID=$(id -g $USER)
 # To prevent weird errors, img name must capture user:group id since the
 # Dockerfile receives those as args and sets up a /homedir in the image
 # owned by $USER_ID:$GROUP_ID
-IMGNAME="ec-wine-builder-img_${USER_ID}_${GROUP_ID}"
+IMGNAME="ec-slp-wine-builder-img_${USER_ID}_${GROUP_ID}"
 
 info "Creating docker image ..."
 $SUDO docker build -t $IMGNAME \
@@ -85,7 +85,7 @@ FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
     -e GIT_REPO="$GIT_REPO" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
-    --name ec-wine-builder-cont \
+    --name ec-slp-wine-builder-cont \
     -v "$FRESH_CLONE_DIR":/homedir/wine64/drive_c/electroncash:delegated \
     --rm \
     --workdir /homedir/wine64/drive_c/electroncash/contrib/build-wine \


### PR DESCRIPTION
Without this Docker will constantly rebuild your images each time you switch between building EC and EC-SLP.