### PR TITLE
Cash Address: Allow hide of status button in preferences + refactor

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -522,12 +522,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
 
     @classmethod
     def show_cashaddr(cls, format):
-        if format==1:
-            cls.FMT_UI = cls.FMT_CASHADDR
-        elif format==2:
-            cls.FMT_UI = cls.FMT_SLPADDR
-        else:
-            cls.FMT_UI = cls.FMT_LEGACY
+        cls.FMT_UI = format
 
 
     @classmethod

--- a/electroncash_gui/qt/address_dialog.py
+++ b/electroncash_gui/qt/address_dialog.py
@@ -125,7 +125,7 @@ class AddressDialog(PrintError, WindowModalDialog):
 
     def connect_signals(self):
         # connect slots so the embedded history list gets updated whenever the history changes
-        self.parent.cashaddr_toggled_signal.connect(self.update_addr)
+        self.parent.gui_object.cashaddr_toggled_signal.connect(self.update_addr)
         self.parent.history_updated_signal.connect(self.hw.update)
         self.parent.labels_updated_signal.connect(self.hw.update_labels)
         self.parent.network_signal.connect(self.got_verified_tx)
@@ -136,7 +136,7 @@ class AddressDialog(PrintError, WindowModalDialog):
         except TypeError: pass
         try: self.parent.network_signal.disconnect(self.got_verified_tx)
         except TypeError: pass
-        try: self.parent.cashaddr_toggled_signal.disconnect(self.update_addr)
+        try: self.parent.gui_object.cashaddr_toggled_signal.disconnect(self.update_addr)
         except TypeError: pass
         try: self.parent.labels_updated_signal.disconnect(self.hw.update_labels)
         except TypeError: pass

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -65,7 +65,7 @@ class RequestList(MyTreeWidget):
         self.parent.receive_address_e.setText(addr.to_full_ui_string())
         self.parent.receive_message_e.setText(message)
         if req.get('token_id', None):
-            self.parent.toggle_cashaddr(2, True)
+            self.parent.gui_object.toggle_cashaddr(Address.FMT_SLPADDR)
             self.parent.receive_slp_token_type_label.setDisabled(False)
             self.parent.receive_slp_amount_e.setDisabled(False)
             self.parent.receive_slp_amount_label.setDisabled(False)
@@ -78,7 +78,7 @@ class RequestList(MyTreeWidget):
             self.parent.receive_amount_e.setText("")
             self.parent.receive_slp_amount_e.setText(str(amount))
         else:
-            self.parent.toggle_cashaddr(1, True)
+            self.parent.gui_object.toggle_cashaddr(Address.FMT_CASHADDR)
             self.parent.receive_token_type_combo.setCurrentIndex(0)
             self.parent.receive_slp_token_type_label.setDisabled(True)
             self.parent.receive_slp_amount_e.setDisabled(True)

--- a/electroncash_gui/qt/transaction_dialog.py
+++ b/electroncash_gui/qt/transaction_dialog.py
@@ -388,7 +388,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
                 try: parent.labels_updated_signal.disconnect(self.update_tx_if_in_wallet)
                 except TypeError: pass
                 for slot in self.cashaddr_signal_slots:
-                    try: parent.cashaddr_toggled_signal.disconnect(slot)
+                    try: parent.gui_object.cashaddr_toggled_signal.disconnect(slot)
                     except TypeError: pass
                 self.cashaddr_signal_slots = []
 
@@ -698,7 +698,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         o_text.setTextInteractionFlags(o_text.textInteractionFlags() | Qt.LinksAccessibleByMouse | Qt.LinksAccessibleByKeyboard)
         vbox.addWidget(o_text)
         self.cashaddr_signal_slots.append(self.update_io)
-        self.main_window.cashaddr_toggled_signal.connect(self.update_io)
+        self.main_window.gui_object.cashaddr_toggled_signal.connect(self.update_io)
         self.update_io()
 
     def add_slp_info(self, vbox):


### PR DESCRIPTION
The user may elect to disable/hide the cash address toggle button in preferences.  See Preferences -> General.

In addition the Preferences -> General tab has been laid out a little bit differently with the Address format set as a combo box rather than a checkbox (this is more to allow for future/SLP).

A checkbox was also added to Preferences -> General to allow hiding of the status bar button app-wide (in case the user wants to avoid status bar clutter). The status bar button is shown on new installs/by default.

Additionally, internal code refactorings are in this commit to move the 'cashaddr_toggled_signal' from a per-window signal to an app-global signal (moved to ElectrumGui instance).  It makes more sense for it to be a single app-wide signal as it's really an app-wide setting.

An additional signal was added, cashaddr_status_button_hidden_signal as an app-wide signal for when the status button gets hidden (all windows listen for this signal and act accordingly).