### PR TITLE
Cli/RPC improvements

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -197,7 +197,7 @@ class Commands(PrintError):
             raise AddressError(f'Invalid address: {address}') from e
 
         if self.config.get("allow_cli_slp_address_conversion") != True:
-            print("WARNING: If you are converting from legacy or cash address to slp format you need \n" + 
+            print("WARNING: If you are converting from legacy or cash address to slp format you need \n" +
                 "to make sure the receiving wallet is compatible with slp tokens protocol. If the wallet \n" +
                 "is not compatible with slp, the receiver's wallet will easily burn tokens. To enable slp \n" +
                 "address conversion you must set the config key 'allow_cli_slp_address_conversion' to 'true'.")
@@ -328,10 +328,10 @@ class Commands(PrintError):
         return self.network.synchronous_get(('blockchain.scripthash.get_history', [sh]))
 
     @command('w')
-    def listunspent(self):
+    def listunspent(self, include_slp=False):
         """List unspent outputs. Returns the list of unspent transaction
         outputs in your wallet."""
-        l = self.wallet.get_utxos(exclude_frozen=False)
+        l = self.wallet.get_utxos(exclude_frozen=False, exclude_slp=not include_slp)
         for i in l:
             v = i["value"]
             i["value"] = str(PyDecimal(v)/COIN) if v is not None else None
@@ -1165,6 +1165,7 @@ command_options = {
     'use_net':     (None, "Go out to network for accurate fiat value and/or fee calculations for history. If not specified only the wallet's cache is used which may lead to inaccurate/missing fees and/or FX rates."),
     'wallet_path': (None, "Wallet path(create/restore commands)"),
     'year':        (None, "Show history for a given year"),
+    'include_slp': (None, "Include SLP UTXOs"),
 }
 
 

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -984,6 +984,16 @@ class Commands(PrintError):
         return list(map(self._format_request, out))
 
     @command('w')
+    def listslptokens(self):
+        """ Return list of wallet tokens """
+        token_types = self.wallet.token_types
+        token_list = list()
+        for token in token_types:
+            token_list.append({'name': token_types[token]['name'], 'token_id': token})
+
+        return token_list
+
+    @command('w')
     def maintainaddressgap(self, enable):
         """Enable or disable the automatic address gap maintenance for receiving addresses."""
         if not isinstance(self.wallet, Deterministic_Wallet):

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -728,6 +728,8 @@ class Commands(PrintError):
         if not isinstance(decimals, int):
             # token is unverified or other funny business -- has decimals field as '?'
             raise RuntimeError("Unverified token-id; please verify this token before proceeding")
+        for o in outputs:
+            o[1] = PyDecimal(o[1])
         amount_slp = get_satoshis_nofloat(str(sum([o[1] for o in outputs])), decimals)
         assert amount_slp > 0
         domain = [Address.from_string(a.strip()) for a in from_addr.split(',')] if from_addr else None  # may raise -- note that domain may be any address not just SLP address in wallet.

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2970,7 +2970,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 out['URI'] = '{}:{}?amount={}-{}'.format(networks.net.SLPADDR_PREFIX,
                                                          addr_text, amount_text, token_id)
             else:
-                out['URI'] = '{}:{}?amount={}'.format(networks.net.SLPADDR_PREFIX,
+                addr.show_cashaddr(addr.FMT_CASHADDR)
+                out['URI'] = '{}:{}?amount={}'.format(networks.net.CASHADDR_PREFIX,
                                                       addr_text, amount_text)
         status, conf = self.get_request_status(addr)
         out['status'] = status


### PR DESCRIPTION
This PR adds the following bug fixes and improvements to the CLI/RPC:

- Add "--include_slp" option to the "listunspend" command
- Add "listslptokens" command
- Fixes #209
- Fixes get_payment_request address format/URI preview bug based on SLP usage (affected "addrequest" command)
- Adds SLP support to the "addrequest" command by introducing "--token_id" option